### PR TITLE
Links on lower-resolution Slimmenu also toggle

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -65,7 +65,6 @@ $('ul.slimmenu').slimmenu(
     indentChildren: true,
     childrenIndenter: '&raquo;'
 });
-
 /* start enable link toggle by jamesarthurjohn 
     This allows the links in the lower resolution instance of Slimmenu to toggle multi-level sub-menus when 
     clicking the link  as well as the button. 

--- a/demo.html
+++ b/demo.html
@@ -65,6 +65,17 @@ $('ul.slimmenu').slimmenu(
     indentChildren: true,
     childrenIndenter: '&raquo;'
 });
+
+/* start enable link toggle by jamesarthurjohn 
+    This allows the links in the lower resolution instance of Slimmenu to toggle multi-level sub-menus when 
+    clicking the link  as well as the button. 
+*/
+$(".slimmenu > li > a").each(function(){
+    $(this).click(function(){
+        $(this).siblings('.sub-collapser').click();
+    });
+});
+/* end enable link toggle by jamesarthurjohn */
 </script>
 </body>
 </html>


### PR DESCRIPTION
This allows the links in the lower-resolution instance of Slimmenu to toggle multi-level sub-menu items when clicking them instead of only toggling with the buttons. Changes are commented as "enable link toggle by jamesarthurjohn."
